### PR TITLE
Add DLUAJIT_ENABLE_LUA52COMPAT to compile flags.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,7 @@ install:
 - cmd: git clone -b v2.1 --single-branch --depth=1 https://github.com/fiendish/LuaJIT.git C:\luajit
 - ps: pushd c:\luajit\src
 - ps: (Get-Content msvcbuild.bat) | ForEach-Object { $_ -replace " /MD " , " /MT " } | Set-Content msvcbuild.bat
+- ps: (Get-Content msvcbuild.bat) | ForEach-Object { $_ -replace "@set LJCOMPILE=cl /nologo /c /O2 /W3 /D_CRT_SECURE_NO_DEPRECATE /D_CRT_STDIO_INLINE=__declspec(dllexport)__inline", "@set LJCOMPILE=cl /nologo /c /O2 /W3 /D_CRT_SECURE_NO_DEPRECATE /D_CRT_STDIO_INLINE=__declspec(dllexport)__inline /DLUAJIT_ENABLE_LUA52COMPAT"} | Set-Content msvcbuild.bat
 - cmd: ./msvcbuild.bat
 - cmd: copy luajit.exe C:\
 - cmd: copy lua51.* C:\

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ install:
 - cmd: git clone -b v2.1 --single-branch --depth=1 https://github.com/fiendish/LuaJIT.git C:\luajit
 - ps: pushd c:\luajit\src
 - ps: (Get-Content msvcbuild.bat) | ForEach-Object { $_ -replace " /MD " , " /MT " } | Set-Content msvcbuild.bat
-- ps: (Get-Content msvcbuild.bat) | ForEach-Object { $_ -replace "@set LJCOMPILE=cl /nologo /c /O2 /W3 /D_CRT_SECURE_NO_DEPRECATE /D_CRT_STDIO_INLINE=__declspec(dllexport)__inline", "@set LJCOMPILE=cl /nologo /c /O2 /W3 /D_CRT_SECURE_NO_DEPRECATE /D_CRT_STDIO_INLINE=__declspec(dllexport)__inline /DLUAJIT_ENABLE_LUA52COMPAT"} | Set-Content msvcbuild.bat
+- ps: (Get-Content msvcbuild.bat) -replace "^@set LJCOMPILE=cl /nologo /c /O2 /W3 /D_CRT_SECURE_NO_DEPRECATE /D_CRT_STDIO_INLINE=__declspec\(dllexport\)__inline", "@set LJCOMPILE=cl /nologo /c /O2 /W3 /D_CRT_SECURE_NO_DEPRECATE /D_CRT_STDIO_INLINE=__declspec(dllexport)__inline /DLUAJIT_ENABLE_LUA52COMPAT" | Set-Content msvcbuild.bat
 - cmd: ./msvcbuild.bat
 - cmd: copy luajit.exe C:\
 - cmd: copy lua51.* C:\


### PR DESCRIPTION
This flag enables more Lua 5.2 features without breaking 5.1 ABI compatibility

Other features are only enabled, if LuaJIT is built with -DLUAJIT_ENABLE_LUA52COMPAT:

Via [https://luajit.org/extensions.html](https://luajit.org/extensions.html):

> - goto is a keyword and not a valid variable name anymore.
> - break can be placed anywhere. Empty statements (;;) are allowed.
> - __lt, __le are invoked for mixed types.
> - __len for tables. rawlen() library function.
> - pairs() and ipairs() check for __pairs and __ipairs.
> - coroutine.running() returns two results.
> - table.pack() and table.unpack() (same as unpack()).
> - io.write() and file:write() return file handle instead of true.
> - os.execute() and pipe:close() return detailed exit status.
> - debug.setmetatable() returns object.
> - debug.getuservalue() and debug.setuservalue().
> - Remove math.mod(), string.gfind().
> 
> Note: this provides only partial compatibility with Lua 5.2 at the language and Lua library level. LuaJIT is API+ABI-compatible with Lua 5.1, which prevents implementing features that would otherwise break the Lua/C API and ABI (e.g. _ENV).